### PR TITLE
HHH-10708 - Fix test case

### DIFF
--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/HHH_10708/BarOne.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/HHH_10708/BarOne.java
@@ -1,0 +1,22 @@
+package org.hibernate.test.bytecode.enhancement.lazy.HHH_10708;
+
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+@Entity
+class BarOne {
+    static final String FOO = "foo";
+
+    @Id
+    @GeneratedValue
+    int id;
+
+    @ManyToOne
+    @Cache( usage = CacheConcurrencyStrategy.READ_WRITE )
+    FooOne foo;
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/HHH_10708/BarTwo.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/HHH_10708/BarTwo.java
@@ -1,0 +1,20 @@
+package org.hibernate.test.bytecode.enhancement.lazy.HHH_10708;
+
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToMany;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+class BarTwo {
+
+    @Id
+    @GeneratedValue
+    int id;
+
+    @ManyToMany( fetch = FetchType.LAZY, targetEntity = FooTwo.class )
+    Set<FooTwo> foos = new HashSet<>();
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/HHH_10708/FooOne.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/HHH_10708/FooOne.java
@@ -1,0 +1,23 @@
+package org.hibernate.test.bytecode.enhancement.lazy.HHH_10708;
+
+import org.hibernate.annotations.Cascade;
+import org.hibernate.annotations.CascadeType;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+class FooOne {
+
+    @Id
+    @GeneratedValue
+    int id;
+
+    @OneToMany( orphanRemoval = true, mappedBy = BarOne.FOO, targetEntity = BarOne.class )
+    @Cascade( CascadeType.ALL )
+    Set<BarOne> bars = new HashSet<>();
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/HHH_10708/FooTwo.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/HHH_10708/FooTwo.java
@@ -1,0 +1,13 @@
+package org.hibernate.test.bytecode.enhancement.lazy.HHH_10708;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+class FooTwo {
+
+    @Id
+    @GeneratedValue
+    int id;
+}

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/HHH_10708/UnexpectedDeleteOneTestTask.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/HHH_10708/UnexpectedDeleteOneTestTask.java
@@ -6,19 +6,7 @@
  */
 package org.hibernate.test.bytecode.enhancement.lazy.HHH_10708;
 
-import java.util.HashSet;
-import java.util.Set;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.ManyToOne;
-import javax.persistence.OneToMany;
-
 import org.hibernate.Session;
-import org.hibernate.annotations.Cache;
-import org.hibernate.annotations.CacheConcurrencyStrategy;
-import org.hibernate.annotations.Cascade;
-import org.hibernate.annotations.CascadeType;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 
@@ -29,7 +17,7 @@ public class UnexpectedDeleteOneTestTask extends AbstractEnhancerTestTask {
 	private int fooId;
 
 	public Class<?>[] getAnnotatedClasses() {
-		return new Class[] {Foo.class, Bar.class};
+		return new Class[] {FooOne.class, BarOne.class};
 	}
 
 	public void prepare() {
@@ -41,9 +29,9 @@ public class UnexpectedDeleteOneTestTask extends AbstractEnhancerTestTask {
 		Session s = getFactory().openSession();
 		s.beginTransaction();
 
-		Bar bar1 = new Bar();
-		Bar bar2 = new Bar();
-		Foo foo = new Foo();
+		BarOne bar1 = new BarOne();
+		BarOne bar2 = new BarOne();
+		FooOne foo = new FooOne();
 		s.save( bar1 );
 		s.save( bar2 );
 		s.save( foo );
@@ -60,7 +48,7 @@ public class UnexpectedDeleteOneTestTask extends AbstractEnhancerTestTask {
 		Session s = getFactory().openSession();
 		s.beginTransaction();
 
-		Foo foo = s.get( Foo.class, fooId );
+		FooOne foo = s.get( FooOne.class, fooId );
 
 		// accessing the collection results in an exception
 		foo.bars.size();
@@ -71,26 +59,6 @@ public class UnexpectedDeleteOneTestTask extends AbstractEnhancerTestTask {
 	}
 
 	protected void cleanup() {
-	}
-
-	@Entity static class Bar {
-		static final String FOO = "foo";
-
-		@Id	@GeneratedValue
-		int id;
-
-		@ManyToOne @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
-		Foo foo;
-	}
-
-	@Entity static class Foo {
-
-		@Id	@GeneratedValue
-		int id;
-
-		@OneToMany(orphanRemoval = true, mappedBy = Bar.FOO, targetEntity = Bar.class)
-		@Cascade(CascadeType.ALL)
-		Set<Bar> bars = new HashSet<>();
 	}
 
 }

--- a/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/HHH_10708/UnexpectedDeleteTwoTestTask.java
+++ b/hibernate-core/src/test/java/org/hibernate/test/bytecode/enhancement/lazy/HHH_10708/UnexpectedDeleteTwoTestTask.java
@@ -6,14 +6,6 @@
  */
 package org.hibernate.test.bytecode.enhancement.lazy.HHH_10708;
 
-import java.util.HashSet;
-import java.util.Set;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.ManyToMany;
-
 import org.hibernate.Session;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
@@ -24,10 +16,10 @@ import org.junit.Assert;
 
 public class UnexpectedDeleteTwoTestTask extends AbstractEnhancerTestTask {
 
-	private Bar myBar;
+	private BarTwo myBar;
 
 	public Class<?>[] getAnnotatedClasses() {
-		return new Class[] {Foo.class, Bar.class};
+		return new Class[] {FooTwo.class, BarTwo.class};
 	}
 
 	public void prepare() {
@@ -40,9 +32,9 @@ public class UnexpectedDeleteTwoTestTask extends AbstractEnhancerTestTask {
 		Session s = getFactory().openSession();
 		s.beginTransaction();
 
-		Bar bar = new Bar();
-		Foo foo1 = new Foo();
-		Foo foo2 = new Foo();
+		BarTwo bar = new BarTwo();
+		FooTwo foo1 = new FooTwo();
+		FooTwo foo2 = new FooTwo();
 		s.save( bar );
 		s.save( foo1 );
 		s.save( foo2 );
@@ -73,7 +65,7 @@ public class UnexpectedDeleteTwoTestTask extends AbstractEnhancerTestTask {
 		s = getFactory().openSession();
 		s.beginTransaction();
 
-		Bar bar = s.get( Bar.class, myBar.id );
+		BarTwo bar = s.get( BarTwo.class, myBar.id );
 		Assert.assertFalse( bar.foos.isEmpty() );
 
 		s.flush();
@@ -82,21 +74,6 @@ public class UnexpectedDeleteTwoTestTask extends AbstractEnhancerTestTask {
 	}
 
 	protected void cleanup() {
-	}
-
-	@Entity static class Bar {
-
-		@Id	@GeneratedValue
-		int id;
-
-		@ManyToMany(fetch = FetchType.LAZY, targetEntity = Foo.class)
-		Set<Foo> foos = new HashSet<>();
-	}
-
-	@Entity static class Foo {
-
-		@Id	@GeneratedValue
-		int id;
 	}
 
 }


### PR DESCRIPTION
@gbadner I found out why the test for this issue fails on 5.0. It has to do with resolving the generic type on inner classes. We use it a lot on the tests (IMHO it's good to keep test case and entities in the same compilation unit) but until now there wasn't a case where we had to infer type by looking at the generic signature (say get the type String out of List<String>).

In later versions of hibernate that use javassist 3.19 or above, it can be fixed, but for 5.0 we are fine if we move these classes out to their own compilation units.

See https://github.com/jboss-javassist/javassist/commit/4cdb575d4ea4ebed471f691d60f9d40b372a9fd1
